### PR TITLE
TLCALIPER-27 - change Composer vendor name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ims-global/caliper-php",
+  "name": "umich-its-tl/caliper-php",
   "description": "Caliper PHP Library",
   "keywords": ["caliper"],
   "homepage": "http://www.imsglobal.org",


### PR DESCRIPTION
Just to be on the safe side, change the vendor name to "umich-its-tl" to make it obvious that this is not the original IMS Global version and to avoid possible conflicts when the original is added to Packagist later.
