### PR TITLE
TLCALIPER-11 - Add installation/usage instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ below:
 
             ***NOTE*** - These package and repository values will not work at
             this time with the IMS Global repositories.  The `composer.json`
-            file in caliper-php-public doesn't contain the correct entries.
-            For U-M purposes, substitute the following values for the package
+            file in caliper-php-public doesn't contain the correct entries. This
+            should be corrected with an update in the near future. For U-M
+            purposes, substitute the following values for the package
             and repository, respectively:
 
             ```json

--- a/README.md
+++ b/README.md
@@ -1,55 +1,136 @@
 caliper-php
-================
+===========
 
-caliper-php is a php client for [Caliper](http://www.imsglobal.org) that provides an implementation of the Caliper SensorAPI™.
+caliper-php is a PHP client for [Caliper](http://www.imsglobal.org) that
+provides an implementation of the Caliper SensorAPI™.
 
 ## Getting Started
 
-### Pre-requisites for development:  
+### Pre-requisites for development
 
 * PHP 5.4 required (PHP 5.6 recommended)
 * Ensure you have php5 and php5-json installed:  ```sudo apt-get install php5 php5-json```
 * Install Composer (for dependency management):  ```curl -sS https://getcomposer.org/installer | php```
 * Install dependencies:  ```php composer.phar install```
-* Run tests using the Makefile
+* Run tests using the Makefile: ```make test-caliper```
 
-### Installing and using the Library:
+    The tests require that the `caliper-common-fixtures-public` project be
+    installed in the same parent directory as `caliper-php-public`.  It is
+    available at:
+    https://github.com/IMSGlobal/caliper-common-fixtures-public.git
 
-To install the library, clone the repository from GitHub into your desired application directory.
+### Installing and Using the Library
 
-```
-git clone https://github.com/IMSGlobal/caliper-php.git
-```
+* Installing: There are two ways to install caliper-php.  Either install by cloning the IMS
+Global public version of the caliper-php GitHub repository or use Composer to
+install from that same repository.  The steps for each method are explained
+below:
+    * Cloning caliper-php-public from GitHub
+        * Clone the repository from GitHub into your application's directory
 
-Then, add the following to your PHP script:
+            ```sh
+            git clone https://github.com/IMSGlobal/caliper-php-public.git
+            ```
 
-```
-require_once '/path/to/caliper-php/lib/CaliperSensor.php';
-```
+        * Add the following to your PHP program:
 
-Now you're ready to initialize Caliper and send an event as follows:
+            ```php
+            require_once '/path/to/caliper-php/lib/Caliper/Sensor.php';
+            ```
 
-```
-Caliper::init('org.imsglobal.caliper.php.apikey', [
-       'debug' => true,
-       'host' => 'example.org',
-       'port' => 80,
-       'sendURI' => '/dataStoreURI',
-]);
-// TODO: Define $yourCaliperEventObject
-Caliper::send($yourCaliperEventObject);
-```
+    * Use Composer to install caliper-php-public from GitHub
+        * Update the `composer.json` file in the root directory of your project as follows:
+            * The `require` section should include the following:
 
-Your PHP program should call init() only once, when it responds to a request.
-All parts of your program will then have access to the same Caliper client.
+                ```json
+                {
+                    "require": {
+                        "php": ">=5.4",
+                        "ims-global/caliper-php-public": "1.0.0"
+                    }
+                }
+                ```
 
-### Running an example:
+            * The `repositories` section should include the following:
 
-A simple example program can be found in:
+                ```json
+                {
+                    "repositories": [
+                        {
+                            "type": "vcs",
+                            "url": "https://github.com/IMSGlobal/caliper-php-public.git"
+                        }
+                    ]
+                }
+                ```
 
-  examples/SessionEventSampleApp.php
+            ***NOTE*** - These package and repository values will not work at
+            this time with the IMS Global repositories.  The `composer.json`
+            file in caliper-php-public doesn't contain the correct entries.
+            For U-M purposes, substitute the following values for the package
+            and repository, respectively:
 
-It will attempt to send an event to a data store listener on localhost:8000.  If you have a data store on some other host or port, you can edit the program to point to it.  If you don't have a data store, you can run a simple listener included in:
+            ```json
+            "umich-its-tl/caliper-php": "1.0.1"
+            ```
+
+            ```json
+            "url": "https://github.com/tl-its-umich-edu/caliper-php-public"
+            ```
+
+            This version of caliper-php-public has been modified for U-M use.
+            It includes a new `Options::setHttpHeaders()` feature.
+        * Use Composer to install the package with the command:
+
+            ```sh
+            composer install
+            ```
+
+            Composer will create the `vendor` directory to hold the package and
+            other related information.
+        * Composer will create PHP classes to help you load Caliper (and any other
+            packages it has loaded) into your application.  In your PHP code, use it like:
+
+            ```php
+            /*
+             * If necessary, use set_include_path() to ensure the directory
+             * containing the "vendor" directory is in the PHP include path.
+             */
+            require_once 'vendor/autoload.php';  // Composer loader for Caliper, etc.
+            ```
+* After installing Caliper using one of the methods decribed above, initialize
+it and send an event as follows:
+
+    ```php
+    // Create Caliper sensor object
+    $sensor = new Sensor('your_sensor_id');
+    // Set sensor options
+    $options = (new Options())
+        ->setApiKey('your_authentication_key_for_the_datastore')
+        ->setDebug(true)
+        ->setHost('http://example.org/dataStoreURI');
+    // Register a network transport for the sensor
+    $sensor->registerClient('your_http_transport_id',
+        new Client('your_client_id', $options));
+    // TODO: Define $yourCaliperEventObject
+    // Send a Caliper event object
+    $sensor->send($sensor, $yourCaliperEventObject);
+
+    ```
+
+    Your PHP program needs to create a sensor object only once per request.
+    The sensor object can be reused to send multiple events within the same
+    request.
+
+
+### Running an example
+
+A simple example program can be found in `examples/SessionEventSampleApp.php`.
+
+It will attempt to send an event to a data store listener on localhost:8000.
+If you have a data store on some other host or port, you can edit the program
+to use it instead.  If you don't have a data store, you can run a simple
+listener program included in:
 
 ```
 examples/tools/testListener.sh [optional_port]
@@ -58,7 +139,12 @@ examples/tools/testListener.sh [optional_port]
 That will start a simple PHP web server (on port 8000 by default) that listens for POST requests and dumps the raw contents to the terminal.  If you run this in one terminal window and the example program in another terminal window, you will see the request received in the first window.
 
 ## Documentation
-Documentation is available at [http://www.imsglobal.org/caliper](https://www.imsglobal.org/caliper).
+Documentation is available at
+[http://www.imsglobal.org/caliper](https://www.imsglobal.org/caliper).
+
+caliper-php-public includes as much documentation as possible in the
+form of PHPDoc comments.  These may appear as pop-up help in many IDEs.
+phpDocumentor may be used to turn them into standalone documents.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ provides an implementation of the Caliper SensorAPI™.
 ### Pre-requisites for development
 
 * PHP 5.4 required (PHP 5.6 recommended)
-* Ensure you have php5 and php5-json installed:  ```sudo apt-get install php5 php5-json```
 * Install Composer (for dependency management):  ```curl -sS https://getcomposer.org/installer | php```
 * Install dependencies:  ```php composer.phar install```
 * Run tests using the Makefile: ```make test-caliper```


### PR DESCRIPTION
Added instructions for using Composer to install Caliper.  Corrected other usage instructions as well.

Hint: For easier reviewing, click the `View` button beside the heading for `README.md` in the list on the `Files changed` tab.

**_NOTE**_ - By following the updated instructions in `README.md`, we should be able to use Composer to add caliper-php to the Problem Roulette project.  It will no longer be necessary to include caliper-php directly in the project.

Reviewers: @bkirschn @arwhyte @pushyamig 
